### PR TITLE
Presentation grading criteria

### DIFF
--- a/assets/week4/presentation-grading.md
+++ b/assets/week4/presentation-grading.md
@@ -1,0 +1,41 @@
+# Project presentation evaluation
+
+You will have to present your project to the class during week 4. This
+presentation will be graded and will count for 28% of your final grade.
+
+Grading criteria will be evaluated using a 3-level scale:
+
+* 1: does not meet expectations
+* 2: partially meets expectations
+* 3: totally meets expectations
+
+Grades will be given by several instructors and averaged to obtain the
+final presentation grade.
+
+## Use of best practices (1-3)
+
+Expectation: the project uses the best practices learnt during week 1, 
+or provides a convincing reason to not use them. 
+
+## Skills and technologies learnt (1-3)
+
+Expectation: the project uses skills or technologies learnt by the student
+during the school, through formal presentations or informal interactions.
+
+## Project relevance (1-3)
+
+Expectation: the project is relevant to brain data analysis.
+
+## Clarity (1-3)
+
+Expectation: the presentation is easy to follow, and supported by
+convincing material (e.g., slides).
+
+## Bonuses
+
+* Highly reproducible project (0-1)
+* Technological achievement (0-1)
+* Exciting presentation (0-1)
+* Nice brain picture (0-1)
+* Popular vote (0-1, averaged across all participants)
+

--- a/assets/week4/presentation-grading.md
+++ b/assets/week4/presentation-grading.md
@@ -12,9 +12,9 @@ Grading criteria will be evaluated using a 3-level scale:
 Grades will be given by several instructors and averaged to obtain the
 final presentation grade.
 
-## Use of best practices (1-3)
+## Use of open-science best practices (1-3)
 
-Expectation: the project uses the best practices learnt during week 1, 
+Expectation: the project uses adequate tools and follow open-science best practices learnt during week 1, 
 or provides a convincing reason to not use them. 
 
 ## Skills and technologies learnt (1-3)


### PR DESCRIPTION
Here is a proposed list of grading criteria for the final project presentations. As discussed during our meeting, the logic is to put the emphasis on the learning rather than on project results. It also includes quite a lot of bonuses: theoretical max grade is 17/12 or 142%. If you agree, we could adopt the same criteria for the project reports, with only minimal edits. 
@pbellec @nstikov @jbpoline @ValHayot @gkiar